### PR TITLE
feat: colorize IP addresses in table output with -nc flag to disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ nics: Display information about Network Interface Cards (NICs)
 usage: nics [options]
   -a	show all details on ALL interfaces, includes DHCP info on Windows
   -d	show debug information
-  -i string
-    	interface name
+  -i string interface name
+  -nc no color output
   -v	show program version
 ```
 

--- a/color_windows.go
+++ b/color_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+const enableVirtualTerminalProcessing = 0x0004
+
+func init() {
+	handle := syscall.Handle(os.Stdout.Fd())
+	var mode uint32
+	if err := syscall.GetConsoleMode(handle, &mode); err == nil {
+		syscall.SetConsoleMode(handle, mode|enableVirtualTerminalProcessing)
+	}
+}

--- a/crossPlatform.go
+++ b/crossPlatform.go
@@ -42,3 +42,36 @@ func arrayContains(value string, array []string) bool {
 	}
 	return false
 }
+
+var noColor bool
+
+const (
+	ansiCyan  = "\033[36m"
+	ansiReset = "\033[0m"
+)
+
+// ColorizeIP wraps an IP address string in ANSI cyan color codes.
+func ColorizeIP(ip string) string {
+	if noColor || ip == "" || ip == "N/A" {
+		return ip
+	}
+	return ansiCyan + ip + ansiReset
+}
+
+// ColorizeCIDR colorizes just the IP portion of a CIDR notation address (e.g., 172.22.2.74/24).
+func ColorizeCIDR(cidr string) string {
+	parts := strings.SplitN(cidr, "/", 2)
+	if len(parts) == 2 {
+		return ColorizeIP(parts[0]) + "/" + parts[1]
+	}
+	return ColorizeIP(cidr)
+}
+
+// ColorizeIPList applies ColorizeCIDR to each element in a slice.
+func ColorizeIPList(ips []string) []string {
+	result := make([]string, len(ips))
+	for i, ip := range ips {
+		result[i] = ColorizeCIDR(ip)
+	}
+	return result
+}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/jftuga/nics
 
-go 1.24.1
+go 1.26.0
 
 require (
 	github.com/olekukonko/tablewriter v0.0.5
-	golang.org/x/net v0.38.0
+	golang.org/x/net v0.51.0
 )
 
 require github.com/mattn/go-runewidth v0.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
+golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/nics.go
+++ b/nics.go
@@ -28,7 +28,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-const version = "1.6.2"
+const version = "1.7.0"
 
 func isBriefEntry(ifaceName, macAddr, mtu, flags string, ipv4List, ipv6List []string, debug bool) bool {
 	if debug {
@@ -133,7 +133,7 @@ func networkInterfaces(brief bool, debug bool, singleInterface string) ([]string
 		flags := iface.Flags.String()
 
 		if brief && isBriefEntry(ifaceName, macAddr, mtu, flags, allIPv4, allIPv6, debug) {
-			joined := strings.Join(allIPv4, "\n") // + "\n" + strings.Join(allIPv6, "\n")
+			joined := strings.Join(ColorizeIPList(allIPv4), "\n") // + "\n" + strings.Join(allIPv6, "\n")
 			table.Append([]string{iface.Name, joined, macAddr, mtu, flags})
 			allRenderedInterfaces = append(allRenderedInterfaces, iface.Name)
 			for _, ipWithMask := range allIPv4 {
@@ -146,7 +146,7 @@ func networkInterfaces(brief bool, debug bool, singleInterface string) ([]string
 		if !brief {
 			table.SetAutoWrapText(true)
 			table.SetRowLine(true)
-			table.Append([]string{ifaceName, strings.Join(allIPv4, "\n"), strings.Join(allIPv6, "\n"), macAddr, mtu, strings.Replace(flags, "|", "\n", -1)})
+			table.Append([]string{ifaceName, strings.Join(ColorizeIPList(allIPv4), "\n"), strings.Join(ColorizeIPList(allIPv6), "\n"), macAddr, mtu, strings.Replace(flags, "|", "\n", -1)})
 			allRenderedInterfaces = append(allRenderedInterfaces, iface.Name)
 			for _, ipWithMask := range allIPv4 {
 				ip := strings.Split(ipWithMask, "/")
@@ -227,6 +227,7 @@ func ShortenLeaseDuration(leaseDuration string) string {
 func main() {
 	argsAllDetails := flag.Bool("a", false, "show all details on ALL interfaces, includes DHCP info on Windows")
 	argsDebug := flag.Bool("d", false, "show debug information")
+	flag.BoolVar(&noColor, "nc", false, "no color output")
 	argsVersion := flag.Bool("v", false, "show program version")
 	argsSingleInterface := flag.String("i", "", "interface name")
 

--- a/nics_darwin.go
+++ b/nics_darwin.go
@@ -173,7 +173,7 @@ func renderDHCPTable(allDhcpInfo []map[string]string) {
 	table.SetHeader([]string{"Name", "DHCP Server", "Lease Start", "Lease Expiration", "Lease Duration"})
 	for _, adapter := range allDhcpInfo {
 		shortLeaseDur := ShortenLeaseDuration(adapter["formatted_lease_time"])
-		table.Append([]string{adapter["adapter"], adapter["server_identifier"], adapter["LeaseStartTime"], adapter["LeaseExpirationTime"], shortLeaseDur})
+		table.Append([]string{adapter["adapter"], ColorizeIP(adapter["server_identifier"]), adapter["LeaseStartTime"], adapter["LeaseExpirationTime"], shortLeaseDur})
 	}
 	table.Render()
 }
@@ -223,6 +223,6 @@ func gatewayAndDNS(allIPv4, allIPv6, allRenderedInterfaces []string, brief bool)
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoWrapText(false)
 	table.SetHeader([]string{"Gateway", "DNS 1", "DNS 2"})
-	table.Append([]string{gateway, dns[0], dns[1]})
+	table.Append([]string{ColorizeIP(gateway), ColorizeIP(dns[0]), ColorizeIP(dns[1])})
 	table.Render()
 }

--- a/nics_linux.go
+++ b/nics_linux.go
@@ -182,7 +182,7 @@ func gatewayAndDNS(allIPv4, allIPv6, allRenderedInterfaces []string, brief bool)
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoWrapText(false)
 	table.SetHeader([]string{"Gateway", "DNS 1", "DNS 2"})
-	table.Append([]string{gateway, dns[0], dns[1]})
+	table.Append([]string{ColorizeIP(gateway), ColorizeIP(dns[0]), ColorizeIP(dns[1])})
 
 	table.Render()
 }

--- a/nics_windows.go
+++ b/nics_windows.go
@@ -165,7 +165,7 @@ func renderDHCPTable(ipMapDHCP map[string][]string) {
 	table.SetAutoWrapText(false)
 	table.SetHeader([]string{"IP", "DHCP Server", "Lease Renewed", "Lease Expires"})
 	for ip, dhcpInfo := range ipMapDHCP {
-		table.Append([]string{ip, dhcpInfo[0], dhcpInfo[1], dhcpInfo[2]})
+		table.Append([]string{ColorizeIP(ip), ColorizeIP(dhcpInfo[0]), dhcpInfo[1], dhcpInfo[2]})
 	}
 	table.Render()
 }
@@ -192,10 +192,10 @@ func gatewayAndDNS(allIPv4, allIPv6, allRenderedInterfaces []string, brief bool)
 	table.SetHeader([]string{"Gateway", "DNS 1", "DNS 2"})
 	for ip := range ipMapGateway {
 		if arrayContains(ip, allIPv4) {
-			table.Append([]string{ipMapGateway[ip], dns[0], dns[1]})
+			table.Append([]string{ColorizeIP(ipMapGateway[ip]), ColorizeIP(dns[0]), ColorizeIP(dns[1])})
 		}
 		if arrayContains(ip, allIPv6) {
-			table.Append([]string{ipMapGateway[ip], dns[0], dns[1]})
+			table.Append([]string{ColorizeIP(ipMapGateway[ip]), ColorizeIP(dns[0]), ColorizeIP(dns[1])})
 		}
 		dns[0] = ""
 		dns[1] = ""


### PR DESCRIPTION
## Summary

- IP addresses are now displayed in cyan in all three tables (interfaces, DHCP, gateway/DNS), with CIDR masks (e.g.,
/24) left uncolored
- Added -nc flag to disable color output
- No new dependencies — uses raw ANSI escape codes with a Windows init() to enable virtual terminal processing
- Updated Go from 1.24.1 to 1.26.0 and golang.org/x/net from v0.38.0 to v0.51.0

## Test plan

- [ ] Verify IPs render in cyan on macOS, Linux, and Windows terminals
- [x]  Verify -nc flag disables all colorization
- [ ]  Verify column alignment is correct (tablewriter strips ANSI for width calculation)
- [x]  Verify N/A and empty values are not wrapped in color codes