### PR TITLE
fix: use kernel32.dll SetConsoleMode for Windows ANSI support

### DIFF
--- a/color_windows.go
+++ b/color_windows.go
@@ -5,14 +5,17 @@ package main
 import (
 	"os"
 	"syscall"
+	"unsafe"
 )
 
 const enableVirtualTerminalProcessing = 0x0004
+
+var setConsoleMode = syscall.NewLazyDLL("kernel32.dll").NewProc("SetConsoleMode")
 
 func init() {
 	handle := syscall.Handle(os.Stdout.Fd())
 	var mode uint32
 	if err := syscall.GetConsoleMode(handle, &mode); err == nil {
-		syscall.SetConsoleMode(handle, mode|enableVirtualTerminalProcessing)
+		setConsoleMode.Call(uintptr(handle), uintptr(unsafe.Pointer(uintptr(mode|enableVirtualTerminalProcessing))))
 	}
 }


### PR DESCRIPTION
## Summary

- Fixed build failure when cross-compiling for Windows (GOOS=windows GOARCH=amd64)
- syscall.SetConsoleMode does not exist in Go's syscall package; replaced with direct kernel32.dll call via NewLazyDLL

## Test plan

- [X] Verify GOOS=windows GOARCH=amd64 go build succeeds
- [ ] Verify colored IP output works on Windows terminal